### PR TITLE
fixed batch_insert return handling

### DIFF
--- a/application/libraries/Mongo_db.php
+++ b/application/libraries/Mongo_db.php
@@ -299,14 +299,13 @@ Class Mongo_db{
 		try
 		{
 			$this->db->{$collection}->batchInsert($insert, array('w' => $this->write_concerns, 'j'=>$this->journal));
-			if (isset($insert['_id']))
-			{
-				return ($insert['_id']);
+			foreach($insert as $doc) {
+				if(!isset($doc['_id'])) {
+					show_error("Batch insert of data into MongoDB failed", 500);
+					return (FALSE);
+				}
 			}
-			else
-			{
-				return (FALSE);
-			}
+			return $insert;
 		}
 		catch (MongoCursorException $e)
 		{


### PR DESCRIPTION
Considering that batchInsert affects multiple documents, the condition 
`if (isset($insert['_id']))
 {
    return ($insert['_id']);
 }` will produce an error as it should be
 `$insert[0]['_id']` for the first item as an example.
fixed it by checking that each item is inserted properly.